### PR TITLE
fix #1 escaped error variable in icinga2-commands.conf

### DIFF
--- a/icinga2-commands.conf
+++ b/icinga2-commands.conf
@@ -17,7 +17,7 @@ object CheckCommand "powershell-base" {
             skip_key = true
         }
         END = {
-            value = "; exit $$LastExitCode } catch { Write-Host ('UNKNOWN: ' + $error); exit 3 }"
+            value = "; exit $$LastExitCode } catch { Write-Host ('UNKNOWN: ' + $$error); exit 3 }"
             order = 999
             skip_key = true
         }


### PR DESCRIPTION
Fix for the wrong escaped error variable. 

