### PR TITLE
Added parameter filter scenarios

### DIFF
--- a/check_exchange_health.ps1
+++ b/check_exchange_health.ps1
@@ -18,12 +18,18 @@ Exchange Server to check against (Default: $env:COMPUTERNAME)
 . PARAMETER IgnoreDisabled
 
 Ignore Disabled monitors and don't mark them as Critical (DEFAULT: $true)
+
+. PARAMETER IgnoreScenarios
+
+Ignore a list of scenarios and don't mark them as critical (DEFAULT: empty)
+Example: "Messages.failed.to.be.made.redundant.Monitor","OnPremisesSmtpClientSubmissionMonitor"
+
 #>
 
 param(
     [string] $Server = $env:COMPUTERNAME,
     [boolean] $IgnoreDisabled = $true,
-    [string[]] $Scenarios = @{},
+    [string[]] $IgnoreScenarios = @{},
     [switch] $Verbose
 )
 
@@ -39,8 +45,8 @@ $state = @{}
 $performance = @{}
 
 try {
-    if ($Scenarios.count -gt 0 -and $IgnoreDisabled -eq $true) {
-      $objects = Get-ServerHealth -Identity $Server | Where-Object { $_.Name -notin $Scenarios } | ? alertvalue -ne disabled
+    if ($IgnoreScenarios.count -gt 0 -and $IgnoreDisabled -eq $true) {
+      $objects = Get-ServerHealth -Identity $Server | Where-Object { $_.Name -notin $IgnoreScenarios } | ? alertvalue -ne disabled
     } elseif ($IgnoreDisabled -eq $true) {
       $objects = Get-ServerHealth -Identity $Server | ? alertvalue -ne disabled
     } else {

--- a/check_exchange_health.ps1
+++ b/check_exchange_health.ps1
@@ -23,7 +23,7 @@ Ignore Disabled monitors and don't mark them as Critical (DEFAULT: $true)
 param(
     [string] $Server = $env:COMPUTERNAME,
     [boolean] $IgnoreDisabled = $true,
-    [string[]] $Scenarios,
+    [string[]] $Scenarios = @{},
     [switch] $Verbose
 )
 
@@ -39,8 +39,8 @@ $state = @{}
 $performance = @{}
 
 try {
-    if ($Scenarios) {
-      $objects = Get-ServerHealth -Identity $Server | Where-Object { $_.Name -notin $Scenarios }
+    if ($Scenarios.count -gt 0 -and $IgnoreDisabled -eq $true) {
+      $objects = Get-ServerHealth -Identity $Server | Where-Object { $_.Name -notin $Scenarios } | ? alertvalue -ne disabled
     } elseif ($IgnoreDisabled -eq $true) {
       $objects = Get-ServerHealth -Identity $Server | ? alertvalue -ne disabled
     } else {

--- a/check_exchange_health.ps1
+++ b/check_exchange_health.ps1
@@ -23,6 +23,7 @@ Ignore Disabled monitors and don't mark them as Critical (DEFAULT: $true)
 param(
     [string] $Server = $env:COMPUTERNAME,
     [boolean] $IgnoreDisabled = $true,
+    [string[]] $Scenarios,
     [switch] $Verbose
 )
 
@@ -38,7 +39,9 @@ $state = @{}
 $performance = @{}
 
 try {
-    if ($IgnoreDisabled -eq $true) {
+    if ($Scenarios) {
+      $objects = Get-ServerHealth -Identity $Server | Where-Object { $_.Name -notin $Scenarios }
+    } elseif ($IgnoreDisabled -eq $true) {
       $objects = Get-ServerHealth -Identity $Server | ? alertvalue -ne disabled
     } else {
       $objects = Get-ServerHealth -Identity $Server

--- a/icinga2-commands.conf
+++ b/icinga2-commands.conf
@@ -37,6 +37,7 @@ object CheckCommand "netways/exchange_health" {
 
     arguments += {
         "-Server" = "$exchange_server$"
+        "-IgnoreScenarios" "$exchange_ignore_scenarios$"
     }
     vars.powershell_script = "C:\\Icinga2Exchange\\check_exchange_health.ps1"
 }


### PR DESCRIPTION
### Description
Added a Parameter to the check_exchange_health check to ignore certain monitors. 

As it's nearly impossible to disable some testmonitors or checks which are not apply to the current enviornment. 

Exchange also shows redundant monitor checks unhealthy even if there's no replication between exchange servers.

### Example
-IgnoreScenarios "Messages.failed.to.be.made.redundant.Monitor","UMCallRouterTestMonitor"

