### PR TITLE
Add NextHopDomain to Queues Plugin Output

### DIFF
--- a/check_exchange_queues.ps1
+++ b/check_exchange_queues.ps1
@@ -84,6 +84,8 @@ try {
             Infos = @()
             State = $NagiosUnknown
         }
+        
+        $item.Infos += $object.NextHopDomain
 
         if ($object.Status -ne 'Active' -and $object.Status -ne 'Ready') {
             $item.Criticals += "inactive"

--- a/check_exchange_queues.ps1
+++ b/check_exchange_queues.ps1
@@ -84,8 +84,6 @@ try {
             Infos = @()
             State = $NagiosUnknown
         }
-        
-        $item.Infos += $object.NextHopDomain
 
         if ($object.Status -ne 'Active' -and $object.Status -ne 'Ready') {
             $item.Criticals += "inactive"
@@ -133,6 +131,13 @@ try {
             $item.State = $NagiosWarning
         } else {
             $item.State = $NagiosOk
+        }
+        
+        $nextHopDomain = $object.NextHopDomain
+        if ($nextHopDomain.StartsWith("site:")) {
+            $item.Infos += "To: " + $nextHopDomain.split(";")[0]
+        } else {
+            $item.Infos += "To: " + $nextHopDomain
         }
     }
 


### PR DESCRIPTION
Adding the NextHopDomain allows a much faster fault evaluation. Especially for large exchange landscapes.

Before:
```
[OK] EX01v\2: Ready, deferred (0), locked (0), messages (0)
[OK] EX01v\3: Ready, deferred (0), locked (0), messages (0)
[CRITICAL] EX01v\4: inactive deferred (0), locked (0), messages (3)
```
After:
```
[OK] EX01v\2: Ready, deferred (0), locked (0), messages (0), To: internet
[OK] EX01v\3: Ready, deferred (0), locked (0), messages (0), To: site:xy
[CRITICAL] EX01v\4: inactive deferred (0), locked (0), messages (3), To: site:zy
```